### PR TITLE
feat(bookings): allow any confirmed booking and prelim bookings in th…

### DIFF
--- a/cerberus/models/booking.py
+++ b/cerberus/models/booking.py
@@ -404,7 +404,7 @@ class Booking(models.Model):
         return self.state in self.STATES_MOVEABLE
 
     def can_complete(self) -> bool:
-        return self.end < make_aware(datetime.now())
+        return self.end < make_aware(datetime.now()) or self.state == BookingStates.CONFIRMED.value
 
     def move_booking(self, to: datetime | date) -> bool:
         if not self.can_move:
@@ -466,7 +466,7 @@ class Booking(models.Model):
     @save_after
     @transition(
         field=state,
-        source=BookingStates.CONFIRMED.value,
+        source=[BookingStates.CONFIRMED.value, BookingStates.PRELIMINARY.value],
         target=BookingStates.COMPLETED.value,
         conditions=[can_complete],
     )

--- a/cerberus/tests/test_bookings.py
+++ b/cerberus/tests/test_bookings.py
@@ -258,6 +258,7 @@ def test_transitions(booking):
         ("confirmed", "canceled"),
         ("confirmed", "completed"),
         ("preliminary", "confirmed"),
+        ("preliminary", "completed"),
         ("enquiry", "preliminary"),
         ("canceled", "enquiry"),
     ]


### PR DESCRIPTION
…e past to be completed

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to complete bookings that are in the 'CONFIRMED' state regardless of their end date. Additionally, it allows bookings in the 'PRELIMINARY' state to transition directly to the 'COMPLETED' state.

- **New Features**:
    - Allow bookings in the 'CONFIRMED' state to be completed even if the end date is in the future.
- **Enhancements**:
    - Enable bookings in the 'PRELIMINARY' state to transition directly to the 'COMPLETED' state.

<!-- Generated by sourcery-ai[bot]: end summary -->