### PR TITLE
bengosney/issue956

### DIFF
--- a/cerberus/widgets.py
+++ b/cerberus/widgets.py
@@ -164,8 +164,8 @@ class CheckboxTable(forms.CheckboxSelectMultiple):
         **kwargs,
     ):
         self.model_fields = model_fields
-        if model_titles:
-            self.model_titles = [model_titles.get(field, field.replace(".", " ").title()) for field in model_fields]
+        model_titles = model_titles or {}
+        self.model_titles = [model_titles.get(field, field.replace(".", " ").title()) for field in model_fields]
         self.empty_text = empty_text
         super().__init__(*args, **kwargs)
 

--- a/cerberus/widgets.py
+++ b/cerberus/widgets.py
@@ -189,7 +189,7 @@ class CheckboxTable(forms.CheckboxSelectMultiple):
                     col_value = col_value()
 
                 col_name = model_field.replace(".", "__")
-                if isinstance(col_value, Iterable):
+                if isinstance(col_value, Iterable) and not isinstance(col_value, str):
                     col_value = ", ".join(str(i) for i in col_value)
                 option["columns"][f"{col_name}"] = col_value
 


### PR DESCRIPTION
- **fix(checkbox-table): ensure we set the column titles**
- **fix(checkbox-table): don't join string values**

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses two bugs in the checkbox table widget. It ensures that column titles are set correctly and prevents string values from being joined when processing iterable column values.

- **Bug Fixes**:
    - Ensure column titles are set correctly in the checkbox table.
    - Prevent joining of string values when processing iterable column values in the checkbox table.

<!-- Generated by sourcery-ai[bot]: end summary -->