### PR TITLE
test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Update Changelog
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   updateChangelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- **docs(readme): remove the dev branch from the readme**
- **build(workflow): correct main branch in the changelog workflow**

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the changelog workflow to use the 'main' branch instead of 'master' and removes references to the 'dev' branch from the README.

- **Build**:
    - Corrected the branch name from 'master' to 'main' in the changelog workflow configuration.
- **Documentation**:
    - Removed references to the 'dev' branch from the README.

<!-- Generated by sourcery-ai[bot]: end summary -->