### PR TITLE
build(workflow): use the commitizen action to bump version on merge to master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,18 +7,11 @@ jobs:
   updateChangelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Update Changelog
-        run: |
-          python3 -m pip install Commitizen
-          cz changelog
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "docs(changelog): update changelog"
-          title: Update Changelog
-          body: Update changelog to reflect release changes
-          branch: update-changelog
-          base: main
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+      - name: Release
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow to use the commitizen action for automating version bumps and changelog updates upon merging to the master branch. It also includes a step for releasing using the softprops action.

- **CI**:
    - Replaced manual changelog update and pull request creation steps with the commitizen action for automated version bumping and changelog generation.

<!-- Generated by sourcery-ai[bot]: end summary -->