### PR TITLE
build(workflow): revert to my changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,16 +6,15 @@ on:
 jobs:
   updateChangelog:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'bump:') && !startsWith(github.event.head_commit.author.username, 'dependabot')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          push: false
+      - name: Update Changelog
+        run: |
+          python3 -m pip install Commitizen
+          cz changelog
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request reverts the changelog workflow to a previous version, removing the commitizen-action and replacing it with a manual changelog update using Commitizen. It also adds a condition to skip the workflow for certain commit messages and authors.

- **Build**:
    - Reverted changelog workflow to a previous version, replacing the use of commitizen-action with a manual changelog update using Commitizen.

<!-- Generated by sourcery-ai[bot]: end summary -->