### PR TITLE
fix(n+1): ignore some n+1 errors

### DIFF
--- a/cerberus/models/booking.py
+++ b/cerberus/models/booking.py
@@ -116,7 +116,7 @@ class BookingSlot(models.Model):
 
     @property
     def can_move(self) -> bool:
-        with zeal_ignore():
+        with zeal_ignore():  # todo: fix the n+1 I'm ignoring
             return all(b.can_move for b in self.bookings.all())
 
     def move_slot(self, start: datetime | date, end: datetime | None = None) -> bool:
@@ -325,7 +325,7 @@ class Booking(models.Model, TransitionActionsMixin):
         return f"{self.name} - {naturaldate(self.start)}"
 
     def save(self, *args, **kwargs) -> None:
-        with transaction.atomic():
+        with transaction.atomic(), zeal_ignore():  # todo: fix the n+1 I'm ignoring
             if self.pk is None and getattr(self, "_booking_slot", None) is None:
                 self._booking_slot = self._get_new_booking_slot()
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request temporarily ignores specific n+1 query errors in the `can_move` property and `save` method of the `Booking` model to prevent immediate issues, with a note to address these errors in the future.

- **Bug Fixes**:
    - Temporarily ignored certain n+1 query errors in the `can_move` property and `save` method of the `Booking` model.

<!-- Generated by sourcery-ai[bot]: end summary -->