### PR TITLE
fix: disable pointer events when fadeing out

### DIFF
--- a/assets/css/toast.css
+++ b/assets/css/toast.css
@@ -23,6 +23,7 @@
 
     &.remove {
       animation: remove 0.3s ease-in-out;
+      pointer-events: none;
     }
 
     &::after {


### PR DESCRIPTION
This will stop the toast getting in the way once dissmissed.

## Summary by Sourcery

Bug Fixes:
- Prevent dismissed toasts from blocking clicks by disabling pointer events during fade-out